### PR TITLE
[Zelda Wind Waker] Why not support JP game workaround？

### DIFF
--- a/Workarounds/WindWakerHD_FPSSlowdownFix/rules.txt
+++ b/Workarounds/WindWakerHD_FPSSlowdownFix/rules.txt
@@ -1,5 +1,5 @@
 [Definition]
-titleIds = 0005000010143500,0005000010143600
+titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = FPS Slowdown
 path = "The Legend of Zelda: The Wind Waker HD/Workarounds/FPS Slowdown"
 description = Fixes slowdown that could occur on weaker hardware.

--- a/Workarounds/WindWakerHD_IntelFixes/rules.txt
+++ b/Workarounds/WindWakerHD_IntelFixes/rules.txt
@@ -1,5 +1,5 @@
 [Definition]
-titleIds = 0005000010143500,0005000010143600
+titleIds = 0005000010143400,0005000010143600,0005000010143500
 name= Graphical fixes for Intel Integrated GPUs
 path = "The Legend of Zelda: The Wind Waker HD/Workarounds/Intel Integrated GPU Fixes"
 description = Fixes graphical bugs while using an Intel iGPU. Don't use this if you're using a Nvidia or AMD GPU.

--- a/Workarounds/WindWakerHD_PictoBox/rules.txt
+++ b/Workarounds/WindWakerHD_PictoBox/rules.txt
@@ -1,5 +1,5 @@
 [Definition]
-titleIds = 0005000010143500,0005000010143600
+titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = Picto-Box Fix
 path = "The Legend of Zelda: The Wind Waker HD/Workarounds/Picto-Box Fix"
 description = This is more of a cheat than workaround. Forces Lenzo to accept any pictures in the quest 'Lenzo's Research Assistant'. Made by Vladimir-1799.


### PR DESCRIPTION
One day i play WindWaker,suddenly i find 3 workaround titleIds is not suport the JP version,so I add a tilelds in that.

titleIds = 0005000010143400,0005000010143600
titleIds = 0005000010143400,0005000010143600,0005000010143500