### PR TITLE
[Splatoon] Add 2.12.1 support.

### DIFF
--- a/src/Splatoon/Graphics/patches.txt
+++ b/src/Splatoon/Graphics/patches.txt
@@ -1,3 +1,29 @@
+[SplatoonV288uw]
+moduleMatches = 0x659C782E
+
+#rodata constants
+
+0x1004364C = .float $width/$height
+0x10124BE0 = .float (($ultrawideHUD == 0) * ($gameWidth/$gameHeight)) + (($ultrawideHUD == 1) * ($width/$height))
+0x10158FE0 = .float $width/$height
+0x10160454 = .float $width/$height
+
+_aspectAddr = 0x1004364C
+_hudAspectAddr = 0x10124BE0
+
+#patches
+
+0x028B1940 = lis r29, _hudAspectAddr@ha ;hud
+0x028B1944 = lfs f13, _hudAspectAddr@l(r29) ;hud
+
+0x02014864 = lis r4, _aspectAddr@ha ;master ar
+0x0201486C = lfs f9, _aspectAddr@l(r4) ;master ar
+
+0x02014570 = lis r4, _aspectAddr@ha ;transition frames
+0x02014578 = lfs f9, _aspectAddr@l(r4)
+0x0201434C = lis r4, _aspectAddr@ha
+0x02014354 = lfs f9, _aspectAddr@l(r4)
+
 [SplatoonV272uw]
 moduleMatches = 0xF7A78809
 

--- a/src/Splatoon/Mods/!NoHUD/patches.txt
+++ b/src/Splatoon/Mods/!NoHUD/patches.txt
@@ -1,3 +1,15 @@
+[SplatoonV288uw]
+moduleMatches = 0x659C782E
+
+#rodata constants
+
+_zeroAddr = 0x02000000
+
+#patches
+
+0x028B1940 = lis r29, _zeroAddr@ha ;hud
+0x028B1944 = lfs f13, _zeroAddr@l(r29) ;hud
+
 [SplatoonV272uw]
 moduleMatches = 0xF7A78809
 

--- a/src/Splatoon/Mods/30FPS/patches.txt
+++ b/src/Splatoon/Mods/30FPS/patches.txt
@@ -1,8 +1,17 @@
+[Splatoon_30FPS_v288]
+moduleMatches = 0x659C782E
+
+# toggles FPS variable, similar to 
+# Exzap's 60fps patch in plaza
+0x2AD5EB0 = lwz r4, 0x304(r31)
+0x2AD5EB4 = ori r4, r4, 1
+0x2AD5EB8 = stw r4, 0x304(r31)
+
 [Splatoon_30FPS_v272]
 moduleMatches = 0xF7A78809
 
 # toggles FPS variable, similar to 
 # Exzap's 60fps patch in plaza
-0x2ad5e70 = lwz r4, 0x304(r31)
-0x2ad5e74 = ori r4, r4, 1
-0x2ad5e78 = stw r4, 0x304(r31)
+0x2AD5E70 = lwz r4, 0x304(r31)
+0x2AD5E74 = ori r4, r4, 1
+0x2AD5E78 = stw r4, 0x304(r31)

--- a/src/Splatoon/Mods/60FPSPlaza/patches.txt
+++ b/src/Splatoon/Mods/60FPSPlaza/patches.txt
@@ -1,4 +1,4 @@
-[Splatoon_60FPSPlaza_v272]
-moduleMatches = 0xF7A78809
+[Splatoon_60FPSPlaza]
+moduleMatches = 0xF7A78809, 0x659C782E
 
 0x242B09C = nop # prevent switch-to-30-FPS-mode function from being called

--- a/src/Splatoon/Mods/MapSwap/patches.txt
+++ b/src/Splatoon/Mods/MapSwap/patches.txt
@@ -1,5 +1,5 @@
-[Gambit272]
-moduleMatches = 0xF7A78809
+[Gambit_MapSwap]
+moduleMatches = 0xF7A78809, 0x659C782E
 
 # List of maps are in maplist.txt
 0x100F9CE0 = .string "Fld_Tutorial00_Ttr" # Tutorial (Original: Fld_Tutorial00_Ttr)

--- a/src/Splatoon/Mods/Octohax/patches.txt
+++ b/src/Splatoon/Mods/Octohax/patches.txt
@@ -5,8 +5,8 @@ moduleMatches = 0x08ED6677
 0x100D8FEC = .string "Rival00_Hlf"
 #0x100D8FFC = .string "Rival_Squid" #Broken bones, just like safe Octohax
 
-[Gambit272]
-moduleMatches = 0xF7A78809
+[GambitLatest]
+moduleMatches = 0xF7A78809, 0x659C782E
 
 0x100EC3B0 = .string "Rival00"
 0x100EC3BC = .string "Rival00_Hlf"

--- a/src/Splatoon/Mods/SquidSisterSwap/patches.txt
+++ b/src/Splatoon/Mods/SquidSisterSwap/patches.txt
@@ -9,8 +9,8 @@ moduleMatches = 0x08ED6677
 0x100D353C = .byte $marieLetter
 0x100D5568 = .byte $marieLetter
 
-[Gambit272]
-moduleMatches = 0xF7A78809
+[GambitLatest]
+moduleMatches = 0xF7A78809, 0x659C782E
 
 0x100E38EC = .byte $callieLetter
 0x100E5A48 = .byte $callieLetter


### PR DESCRIPTION
Outside from the addresses for the 30FPS and Ultrawide HUD patches, all of the addresses stayed intact in the latest update.
![2023-08-03_00-26-07_Cemu](https://github.com/cemu-project/cemu_graphic_packs/assets/15317421/cd8e5a6e-bad5-4784-af38-59f2db4e1c0a)
![Screenshot_2023-08-03_01-13-43](https://github.com/cemu-project/cemu_graphic_packs/assets/15317421/5299cd4c-02fa-4769-928a-ee4d6afa6a27)
