### PR TITLE
M&S Olympic Games Resolution fixes

### DIFF
--- a/src/M&SSochi2014/Graphics/rules.txt
+++ b/src/M&SSochi2014/Graphics/rules.txt
@@ -1,8 +1,8 @@
 [Definition]
-titleIds = 0005000010190300,00050000101E5300,00050000101E5400
+titleIds = 0005000010106900,000500001010C700,000500001010C800
 name = Graphic Options
-path = "Mario & Sonic at the Rio 2016 Olympic Games/Graphics"
-description = Allows you to change the game's TV resolution, gamepad resolution and anisotropic filtering quality.||Made by M&&M.
+path = "Mario & Sonic at the Sochi 2014 Olympic Winter Games/Graphics"
+description = Allows you to change the game's TV resolution, gamepad resolution and anisotropic filtering quality.||Made by ICUP321.
 version = 6
 
 [Default]


### PR DESCRIPTION
Fixes a strange resolution bug in Mario & Sonic Rio Olympic Games 2016 by updating the code to match Sonic Lost World and adds a Sochi Winter Games 2014 resolutions file as well. 

Not tested extensively for M&S Winter 2014 because of an emulation bug causing crashes a few seconds after the title screen, making it unplayable.

Closes #605 and #606 (2014 runs at 60 FPS consistently though afaik)