### PR TITLE
Fix Mario kart 8 lines bug

### DIFF
--- a/src/MarioKart8/Graphics/rules.txt
+++ b/src/MarioKart8/Graphics/rules.txt
@@ -1012,12 +1012,6 @@ formats = 0x806
 overwriteFormat = 0x820
 
 [TextureRedefine]
-width = 1280
-height = 720
-formats = 0x816
-overwriteFormat = 0x820
-
-[TextureRedefine]
 width = 800
 height = 450
 formats = 0x01a


### PR DESCRIPTION
Fix #573
Before:
![Screenshot_2024-03-10_23-15-32](https://github.com/cemu-project/cemu_graphic_packs/assets/7033575/eb28f5e6-576f-487a-b36b-169aaf6ca659)
After:
![Screenshot_2024-03-10_23-13-32](https://github.com/cemu-project/cemu_graphic_packs/assets/7033575/85bcc147-de5b-4a59-99b2-d40ccc21f740)
Here you can see what the textures look like in RenderDoc
![Screenshot_2024-03-10_23-13-12](https://github.com/cemu-project/cemu_graphic_packs/assets/7033575/4adfd346-a465-4dc1-8e0d-2d8f188b0c64)
![Screenshot_2024-03-10_23-15-51](https://github.com/cemu-project/cemu_graphic_packs/assets/7033575/a166edf0-b77c-4a7d-8334-08f3c6b67a53)

Oddly enough this only happens in OpenGL. Unless there's some rationale as to why this specific format needs to be changed that I'm unaware of it's probably best to remove this format change