### PR TITLE
Added 16:10 resolution to Wind Waker HD (#607)

### DIFF
--- a/Resolutions/WindWakerHD_Resolution/rules.txt
+++ b/Resolutions/WindWakerHD_Resolution/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = Resolution
 path = "The Legend of Zelda: The Wind Waker HD/Graphics/Resolution"
-description = Changes the resolution of the game. Made by getdls and Morph.
+description = Changes the resolution of the game. Made by getdls, Morph and Ryce-Fast.
 version = 4
 
 [Preset]
@@ -130,6 +130,58 @@ $aspectRatio = (16.0/9.0)
 #2560×1080, 5120×2160, 8192×3456	|64:27 (2.370)
 #3440×1440							|43:18 (2.38)
 #1920×800, 3840×1600, 7680×3200		|12:5 (2.4)
+
+
+[Preset]
+name = ---- Steam Deck 16:10 ----
+$width = 1280
+$height = 800
+$gameWidth= 1920
+$gameHeight= 1080
+$lightSource = 1.0
+$scaleShader = 1.0
+$aspectRatio = (16.0/10.0)
+
+[Preset]
+name = 1440x900 (16:10)
+$width = 1440
+$height = 900
+$gameWidth= 1920
+$gameHeight= 1080
+$lightSource = 1.0
+$scaleShader = 1.0
+$aspectRatio = (16.0/10.0)
+
+[Preset]
+name = 1680x1050 (16:10 HD)
+$width = 1680
+$height = 1050
+$gameWidth= 1920
+$gameHeight= 1080
+$lightSource = 1.0
+$scaleShader = 1.0
+$aspectRatio = (16.0/10.0)
+
+[Preset]
+name = 1920x1200 (16:10 HD)
+$width = 1920
+$height = 1200
+$gameWidth= 1920
+$gameHeight= 1080
+$lightSource = 1.0
+$scaleShader = 1.0
+$aspectRatio = (16.0/10.0)
+
+[Preset]
+name = 2560x1600 (16:10 HD+)
+$width = 2560
+$height = 1600
+$gameWidth= 1920
+$gameHeight= 1080
+$lightSource = 1.0
+$scaleShader = 1.0
+$aspectRatio = (16.0/10.0)
+
 
 [Preset]
 name = ---- Ultra wide 21:9 ----


### PR DESCRIPTION
This patch adds 16:10 resolutions to the game Zelda Wind Waker HD. This will allow you to play on Steam Deck. This patch fixes #607.