### PR TITLE
MK8: Fix cup screen black lines

### DIFF
--- a/src/MarioKart8/Graphics/rules.txt
+++ b/src/MarioKart8/Graphics/rules.txt
@@ -1341,7 +1341,7 @@ overwriteHeight = ($height/$gameHeight) * 360
 width = 576
 height = 64
 #formats = 0x019 #,0x01a,0x806,0x816
-overwriteWidth = ($width/$gameWidth) * 560
+overwriteWidth = ($width/$gameWidth) * 576
 overwriteHeight = ($height/$gameHeight) * 64
 
 [TextureRedefine] #Cup win board


### PR DESCRIPTION
Fixed an issue where on the results screen of a Grand Prix race there would be a black bar on the scoreboard.
before:
![screenshotbroken](https://github.com/goeiecool9999/cemu_graphic_packs/assets/7033575/d1407771-e5fb-4419-bf7c-a1a15a5df207)
after:
![Screenshot_2024-03-28_16-40-33](https://github.com/goeiecool9999/cemu_graphic_packs/assets/7033575/c11715b7-c914-4242-a9eb-65e26589752b)
The normal rendering of the scoreboard uses a texture of 576x64 and copies it to a smaller texture of 560x64:
![image](https://github.com/goeiecool9999/cemu_graphic_packs/assets/7033575/b4e4e1d0-e822-444b-a9d5-4e23a08487d5)
![image](https://github.com/goeiecool9999/cemu_graphic_packs/assets/7033575/165b8018-c51e-4607-96dd-45f3fd1aed19)
However the resolution graphic pack puts the source image at the same resolution as the destination, so the image copy doesn't cut off the black/undefined part which shows in the final output.