### PR TITLE
BOTW clarity preset "Cobalt (Saturated & Bright)" [Ready to Merge]

### DIFF
--- a/src/BreathOfTheWild/Enhancements/37040a485a29d54e_00000000000003c9_ps.txt
+++ b/src/BreathOfTheWild/Enhancements/37040a485a29d54e_00000000000003c9_ps.txt
@@ -39,6 +39,7 @@
 	// MaranBr Preset (Little More Intense) 16
 	// YeMaoWuXin's Preset (Bright colors) 17
 	// YeMaoWuXin's Preset (Vivid and clear) 18
+	// Cobalt's Preset (Saturated & Bright) 19
 	
 //##########################################################													   
 
@@ -1405,6 +1406,74 @@ float DPX_Strength = 0.20;
 	float Colorfulness = 1.0;
 	float DPX_Strength = 0.10;
 	
+#elif (Preset == 19) // Cobalt's preset (Saturated & Bright)
+
+	#define adjust_bloom 1
+	const float bloomFactor = 1.00;
+	#define HDRpassing 0
+	const float HDRPower = 1.00;
+	const float radius1 = 1.00; 
+	const float radius2 = 0.80;
+	#define lumapassing 0
+	const float sharp_strength = 0.35;
+	const float sharp_clamp = 0.85; 
+	const float offset_bias = 1.0;
+	#define Tone_map 0
+	const float Exposure = 1.17;
+	const float Bleach = 0.4;
+	const float Gamma = 1.00; 
+	const float defog = 0.00;
+	vec3 FogColor = vec3(1.0, 1.0, 1.0);
+	const float sat = 0.000;
+	const float crushContrast = 0.000;
+	#define post_process 0
+	const float satFactor = 0.17;
+	#define blacknwhitepass 0
+	const int BlackPoint = 1;
+	const int WhitePoint = 235;
+	#define lggpass 0
+	vec3 RGB_Lift = vec3(1.000, 1.000, 1.000);
+	vec3 RGB_Gamma = vec3(1.000, 1.000, 1.000);
+	vec3 RGB_Gain = vec3(1.000, 1.000, 1.000);
+	#define vibpass 1
+	const float Vibrance = 0; 
+	vec3 VibranceRGBBalance = vec3(1.0, 1.0, 1.0);
+	#define Tech 0								
+	const float Power = 4.0;
+	vec3 RGBNegativeAmount = vec3(0.88, 0.88, 0.88);
+	float Strength = 0.20;
+	#define Techine 0
+	const float Technicolor2_Red_Strength = 0.02;
+	const float Technicolor2_Green_Strength = 0.02;
+	const float Technicolor2_Blue_Strength = 0.02;
+	const float Technicolor2_Brightness = 1.00;   
+	const float Technicolor2_Strength = 1.00;
+	const float Technicolor2_Saturation = 1.00;
+	#define cmatrix 0
+	vec3 ColorMatrix_Red = vec3(0.817, 0.183, 0.000);
+	vec3 ColorMatrix_Green = vec3(0.333, 0.667, 0.000);
+	vec3 ColorMatrix_Blue = vec3(0.000, 0.125, 0.875);
+	float CM_Strength = 1.0;
+	#define CurvesPss 1 
+	const float Contrast = 0.74;
+	#define Filmicpass 0 
+	const float Filmic_Contrast = 1.0;
+	const float Filmic_Bleach = 0.0;  
+	const float Saturation = -0.15;
+	const float Filmic_Strength = 0.85; 
+	const float Fade = 0.4;        
+	const float Linearization = 0.5;               
+	const float BaseCurve = 1.5;  
+	const float BaseGamma = 1.00; 
+	const float EffectGamma = 0.68;
+	#define dpxpass 0
+	vec3 RGB_Curve = vec3(8.0, 8.0, 8.0);
+	vec3 RGB_C = vec3(0.36, 0.36, 0.34);
+	float DPX_Contrast = 0.1;
+	float DPX_Saturation = 3.0;
+	float Colorfulness = 2.5;
+	float DPX_Strength = 0.20;
+
 #endif
 
 //###########################################################

--- a/src/BreathOfTheWild/Enhancements/rules.txt
+++ b/src/BreathOfTheWild/Enhancements/rules.txt
@@ -114,6 +114,11 @@ category = Clarity
 $preset:int = 18
 
 [Preset]
+name = Cobalt's Preset (Saturated & Bright)
+category = Clarity
+$preset:int = 19
+
+[Preset]
 name = User-Defined Preset
 category = Clarity
 $preset:int = 0


### PR DESCRIPTION
01
**With** clarity preset:
![link_new](https://github.com/user-attachments/assets/20178265-77b0-47ef-bc4d-d044a95b0e2a)
Without clarity preset:
![link_old](https://github.com/user-attachments/assets/71744d0b-0a9c-47f8-8261-be77433580c0)

02
**With** clarity preset:
![old_new2](https://github.com/user-attachments/assets/8fadd2cc-89c3-4ee3-80eb-a2f6ee8f7bd2)
Without clarity preset:
![link_old2](https://github.com/user-attachments/assets/115226f0-e519-420e-9f2c-23c08552307b)

03
**With** clarity preset:
![link_new3](https://github.com/user-attachments/assets/7d64114a-ff66-435c-8c1d-2508640a56e6)
Without clarity preset:
![link_old3](https://github.com/user-attachments/assets/41434dd9-d1a9-4438-9e4f-c2a495f6afd6)


I've been playing ~10 hours all around with this preset so far and really enjoying it, seems to work well in all areas. It gets rid of that vanilla desaturation basically. A lot of presets change the overall colors too much. I wanted something closer to vanilla just more saturated. I went through and tried all the existing presets and this one still feels like a unique add.

[Ready to merge]
