### PR TITLE
Skylanders: Fix infinite fall softlock at high FPS

### DIFF
--- a/src/SkylandersSuperChargers/Mods/FPS/patch_FixInfiniteFall.asm
+++ b/src/SkylandersSuperChargers/Mods/FPS/patch_FixInfiniteFall.asm
@@ -1,0 +1,51 @@
+[SSC_FixInfiniteFall]
+moduleMatches = 0xccf357b3, 0x1407432e, 0x3a1208f7, 0x21fc6048, 0x3e598867, 0xcf77bcd5, 0x25a11655
+.origin = codecave
+
+const_stuckFallingDistanceThreshold:
+.float 20*30/$targetFPS
+
+_getStuckFallingDistanceThreshold_f13:
+    lis r0, const_stuckFallingDistanceThreshold@ha
+    lfs f13, const_stuckFallingDistanceThreshold@l(r0)
+blr
+
+_getStuckFallingDistanceThreshold_f0:
+    lis r0, const_stuckFallingDistanceThreshold@ha
+    lfs f0, const_stuckFallingDistanceThreshold@l(r0)
+blr
+
+[SSC_FixInfiniteFall_V1]
+moduleMatches = 0xccf357b3 ; v1
+
+0x0220e028 = bla _getStuckFallingDistanceThreshold_f0
+
+[SSC_FixInfiniteFall_V16]
+moduleMatches = 0x1407432e ; 1.1.0
+
+0x0220c35c = bla _getStuckFallingDistanceThreshold_f13
+
+[SSC_FixInfiniteFall_V32]
+moduleMatches = 0x3a1208f7 ; 1.2.0
+
+0x0220d958 = bla _getStuckFallingDistanceThreshold_f13
+
+[SSC_FixInfiniteFall_V48]
+moduleMatches = 0x21fc6048 ; 1.3.0
+
+0x0220f940 = bla _getStuckFallingDistanceThreshold_f13
+
+[SSC_FixInfiniteFall_V64]
+moduleMatches = 0x3e598867 ; 1.4.0
+
+0x02210e78 = bla _getStuckFallingDistanceThreshold_f13
+
+[SSC_FixInfiniteFall_V80]
+moduleMatches = 0xcf77bcd5 ; 1.5.0
+
+0x02212da8 = bla _getStuckFallingDistanceThreshold_f13
+
+[SSC_FixInfiniteFall_V96_V97]
+moduleMatches = 0x25a11655 ; 1.6.1 (v96 in US, v97 in EU)
+
+0x02212da8 = bla _getStuckFallingDistanceThreshold_f13

--- a/src/SkylandersSuperChargers/Mods/FPS/rules.txt
+++ b/src/SkylandersSuperChargers/Mods/FPS/rules.txt
@@ -2,8 +2,8 @@
 titleIds = 00050000101BFC00,00050000101B8500
 name = FPS
 path = "Skylanders: Superchargers/Mods/FPS"
-description = Changes the game's FPS limit.|Running the game with a high FPS limit can result in glitches.||Made by Mew00, Winner Nombre and DigitNetics.
-version = 7
+description = Changes the game's FPS limit.|Running the game with a high FPS limit can result in glitches.||Made by Mew00, and DigitNetics. Infinite fall fix by SuperSamus and Winner Nombre.
+version = 6
 
 [Default]
 $targetFPS:int = 30

--- a/src/SkylandersSwapForce/Mods/FPS/patch_FixInfiniteFall.asm
+++ b/src/SkylandersSwapForce/Mods/FPS/patch_FixInfiniteFall.asm
@@ -1,0 +1,21 @@
+[SSF_FixInfiniteFall]
+moduleMatches = 0xa0b35374, 0xb1f102ec ; v16, v0
+.origin = codecave
+
+const_stuckFallingDistanceThreshold:
+.float 20*30/$targetFPS
+
+_getStuckFallingDistanceThreshold:
+    lis r0, const_stuckFallingDistanceThreshold@ha
+    lfs f0, const_stuckFallingDistanceThreshold@l(r0)
+blr
+
+[SSF_FixInfiniteFall_V16]
+moduleMatches = 0xa0b35374 ; v16
+
+0x0242729c = bla _getStuckFallingDistanceThreshold
+
+[SSF_FixInfiniteFall_V0]
+moduleMatches = 0xb1f102ec ; v0
+
+0x02427214 = bla _getStuckFallingDistanceThreshold

--- a/src/SkylandersSwapForce/Mods/FPS/rules.txt
+++ b/src/SkylandersSwapForce/Mods/FPS/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010139200,0005000010140400
 name = FPS
 path = "Skylanders Swap Force/Mods/FPS"
-description = Changes the game's dynamic FPS target. Might have bugs, especially when going above 120 FPS.||Made by Mew00 for Imaginators, added by TheSkyDude134 for Swap Force.
+description = Changes the game's dynamic FPS target. Might have bugs, especially when going above 120 FPS.||Made by Mew00 for Imaginators, added by TheSkyDude134 for Swap Force. Infinite fall fix by SuperSamus and Winner Nombre.
 version = 6
 
 [Default]


### PR DESCRIPTION
Fixes one of the issues caused by higher framerates in the Skylanders saga: #615.

The reason why the character was respawning during long falls is because of a failsafe meant in case your character is stuck falling between geometry.
The game determines whether you are stuck with a simple method: it calculates the squared distance of your character from the position of the previous frame, then checks whether it's lower than 20². If that's true for 3 seconds, then it teleports you.
But if the framerate is higher, your distance is going to be lower than normal, and the game will consider you stuck even when falling at top speed.
Ironic...

The fix simply consists in overriding the load of 20.0, and load `20×30FPS/targetFPS` instead.
(Ideally you would multiply by `deltaTime` instead of dividing by `targetFPS`, but since it's not already loaded in a register in that part, not bothering.)

Before:

https://github.com/user-attachments/assets/c6215296-79bd-4a04-810e-b9f35508fbd0

After:

https://github.com/user-attachments/assets/74097add-1df3-4f8a-92f8-3463367f13d8

Credits:
- Me for understanding and patching the issue on the Wii version of Swap Force.
- @WinnerNombre for finding the addresses for the Wii U games. (And for the videos.)

This is currently a draft, as this is only one version of one game, so not worth merging now. More games and versions will be added later.
I'm leaving this for documentation and for reference.

Other things for reference:
- For games that have debug symbols, the function is named `updateStuckFallingCheck`.