### PR TITLE
[Rise of Lyric] Note Knuckles jump glitch in Fix Pause State Reset

### DIFF
--- a/src/SonicBoomRiseOfLyric/Mods/FixPauseStateReset/rules.txt
+++ b/src/SonicBoomRiseOfLyric/Mods/FixPauseStateReset/rules.txt
@@ -2,5 +2,5 @@
 titleIds = 0005000010175B00,0005000010177800,0005000010191F00
 name = Fix Pause State Reset
 path = "Sonic Boom: Rise of Lyric/Mods/Fix Pause State Reset"
-description = This patches out an issue where all players' states reset to idle after unpausing the game.||Made by HyperBE32.
+description = This patches out an issue where all players' states reset to idle after unpausing the game.|This fixes the infamous Knuckles infinite jump glitch.||Made by HyperBE32.
 version = 6


### PR DESCRIPTION
Adding as a note after watching a friend play the game and question why the glitch wasn't working, then seeing this pack enabled lol