### PR TITLE
[BOTW] Make Option-Orders consistent

### DIFF
--- a/src/BreathOfTheWild/Enhancements/rules.txt
+++ b/src/BreathOfTheWild/Enhancements/rules.txt
@@ -126,14 +126,14 @@ $preset:int = 0
 # Depth of Field
 
 [Preset]
-name = Enabled
-category = Depth Of Field
-default = 1
-
-[Preset]
 name = Disabled (no performance gain)
 category = Depth Of Field
 $disableDOF:int = 1
+
+[Preset]
+name = Enabled
+category = Depth Of Field
+default = 1
 
 # Enhanced Reflections
 
@@ -187,9 +187,19 @@ $sampleCount:int = 64
 # Anisotropic Filtering
 
 [Preset]
-name = Extreme (16x)
+name = Low (1x)
 category = Anisotropic Filtering
-$anisotropy = 16
+$anisotropy = 1
+
+[Preset]
+name = Medium (2x)
+category = Anisotropic Filtering
+$anisotropy = 2
+
+[Preset]
+name = High (4x)
+category = Anisotropic Filtering
+$anisotropy = 4
 
 [Preset]
 name = Ultra (8x, Default)
@@ -198,19 +208,9 @@ default = 1
 $anisotropy = 8
 
 [Preset]
-name = High (4x)
+name = Extreme (16x)
 category = Anisotropic Filtering
-$anisotropy = 4
-
-[Preset]
-name = Medium (2x)
-category = Anisotropic Filtering
-$anisotropy = 2
-
-[Preset]
-name = Low (1x)
-category = Anisotropic Filtering
-$anisotropy = 1
+$anisotropy = 16
 
 
 [TextureRedefine]

--- a/src/BreathOfTheWild/Graphics/rules.txt
+++ b/src/BreathOfTheWild/Graphics/rules.txt
@@ -509,9 +509,9 @@ $ultrawideHUDMode:int = 0
 # Anti-Aliasing
 
 [Preset]
-name = Normal FXAA (Default)
+name = None
 category = Anti-Aliasing
-default = 1
+$fxaa:int = 0
 
 [Preset]
 name = NVIDIA FXAA
@@ -519,9 +519,9 @@ category = Anti-Aliasing
 $fxaa:int = 2
 
 [Preset]
-name = None
+name = Normal FXAA (Default)
 category = Anti-Aliasing
-$fxaa:int = 0
+default = 1
 
 # Shadow Graphics Pack
 


### PR DESCRIPTION
For a consistent UX-Experience, Presets considered as "LOW" or "OFF" should always be put on top, while "HIGH" or "ON" should be on the bottom, eg `low -> medium -> high -> max`

The BOTW GraphicPacks category seems like it could not decide, and just screwed the order entirely, leading to some doing it like this, and some like that.

This PR re-orders the options from the Enhancements and Graphics categories. I left others untouched (eg Cheats and Mods), because they apparently follow the `default -> non-default` order. 

Would close #591