### PR TITLE
[MK8/Splatoon/Minecraft] Add overrides for the peer-to-peer/multiplayer ports

### DIFF
--- a/Workarounds/MinecraftWiiUEdition_NetworkPort/patch_port.asm
+++ b/Workarounds/MinecraftWiiUEdition_NetworkPort/patch_port.asm
@@ -1,0 +1,14 @@
+[MinecraftWiiU_ForceMultiplayerPortNumber_v688]
+moduleMatches = 0x867317DE
+
+# GetRandomPortRangeMin
+.origin = 0x03579530
+li  r3, 0
+ori r3, r3, $port
+blr
+
+# GetRandomPortRangeMax
+.origin = 0x0357953c
+li  r3, 0
+ori r3, r3, $port
+blr

--- a/Workarounds/MinecraftWiiUEdition_NetworkPort/rules.txt
+++ b/Workarounds/MinecraftWiiUEdition_NetworkPort/rules.txt
@@ -1,0 +1,59 @@
+[Definition]
+titleIds = 00050000101D9D00,00050000101D7500,00050000101DBE00
+name = Multiplayer network port
+path = "Minecraft: Wii U Edition/Workarounds/Multiplayer network port"
+description = Forces peer-to-peer multiplayer to use a certain network port number, so that you can port forward it in your router.||This might help with connecting to online services, or with some 118-XXXX errors.
+version = 6
+
+[Default]
+$port = 58000
+
+[Preset]
+name = UDP 58000
+category = Use network port
+$port = 58000
+
+[Preset]
+name = UDP 58001
+category = Use network port
+$port = 58001
+
+[Preset]
+name = UDP 58002
+category = Use network port
+$port = 58002
+
+[Preset]
+name = UDP 58003
+category = Use network port
+$port = 58003
+
+[Preset]
+name = UDP 58004
+category = Use network port
+$port = 58004
+
+[Preset]
+name = UDP 58005
+category = Use network port
+$port = 58005
+
+[Preset]
+name = UDP 58006
+category = Use network port
+$port = 58006
+
+[Preset]
+name = UDP 58007
+category = Use network port
+$port = 58007
+
+[Preset]
+name = UDP 58008
+category = Use network port
+$port = 58008
+
+[Preset]
+name = UDP 58009
+category = Use network port
+$port = 58009

--- a/src/MarioKart8/NetworkPort/patch_port.asm
+++ b/src/MarioKart8/NetworkPort/patch_port.asm
@@ -1,0 +1,7 @@
+[MarioKart8_ForceMultiplayerPortNumber_v81]
+moduleMatches = 0x9F0A90B7
+
+# min port range
+0x101a9a52 = .short $port
+# max port range
+0x101a9a54 = .short $port

--- a/src/MarioKart8/NetworkPort/rules.txt
+++ b/src/MarioKart8/NetworkPort/rules.txt
@@ -1,0 +1,59 @@
+[Definition]
+titleIds = 000500001010ec00,000500001010ed00,000500001010eb00
+name = Multiplayer network port
+path = "Mario Kart 8/Workarounds/Multiplayer network port"
+description = Forces peer-to-peer multiplayer to use a certain network port number, so that you can port forward it in your router.||This might help with connecting to online services, or with some 118-XXXX errors.
+version = 6
+
+[Default]
+$port = 58000
+
+[Preset]
+name = UDP 58000
+category = Use network port
+$port = 58000
+
+[Preset]
+name = UDP 58001
+category = Use network port
+$port = 58001
+
+[Preset]
+name = UDP 58002
+category = Use network port
+$port = 58002
+
+[Preset]
+name = UDP 58003
+category = Use network port
+$port = 58003
+
+[Preset]
+name = UDP 58004
+category = Use network port
+$port = 58004
+
+[Preset]
+name = UDP 58005
+category = Use network port
+$port = 58005
+
+[Preset]
+name = UDP 58006
+category = Use network port
+$port = 58006
+
+[Preset]
+name = UDP 58007
+category = Use network port
+$port = 58007
+
+[Preset]
+name = UDP 58008
+category = Use network port
+$port = 58008
+
+[Preset]
+name = UDP 58009
+category = Use network port
+$port = 58009

--- a/src/Splatoon/NetworkPort/patch_port.asm
+++ b/src/Splatoon/NetworkPort/patch_port.asm
@@ -1,0 +1,7 @@
+[Splatoon_ForceMultiplayerPortNumber_v288]
+moduleMatches = 0x659C782E
+
+# min port range
+0x101e8952 = .short $port
+# max port range
+0x101e8954 = .short $port

--- a/src/Splatoon/NetworkPort/rules.txt
+++ b/src/Splatoon/NetworkPort/rules.txt
@@ -1,0 +1,59 @@
+[Definition]
+titleIds = 0005000010176900,0005000010176A00,0005000010162B00
+name = Multiplayer network port
+path = "Splatoon/Workarounds/Multiplayer network port"
+description = Forces peer-to-peer multiplayer to use a certain network port number, so that you can port forward it in your router.||This might help with connecting to online services, or with some 118-XXXX errors.
+version = 6
+
+[Default]
+$port = 58000
+
+[Preset]
+name = UDP 58000
+category = Use network port
+$port = 58000
+
+[Preset]
+name = UDP 58001
+category = Use network port
+$port = 58001
+
+[Preset]
+name = UDP 58002
+category = Use network port
+$port = 58002
+
+[Preset]
+name = UDP 58003
+category = Use network port
+$port = 58003
+
+[Preset]
+name = UDP 58004
+category = Use network port
+$port = 58004
+
+[Preset]
+name = UDP 58005
+category = Use network port
+$port = 58005
+
+[Preset]
+name = UDP 58006
+category = Use network port
+$port = 58006
+
+[Preset]
+name = UDP 58007
+category = Use network port
+$port = 58007
+
+[Preset]
+name = UDP 58008
+category = Use network port
+$port = 58008
+
+[Preset]
+name = UDP 58009
+category = Use network port
+$port = 58009


### PR DESCRIPTION
Wii U games have pretty dated netcode that can struggle with modern networks, leading to 118- errors when playing online. Nintendo's recommendation is to place the game in the DMZ, effectively forwarding every port to it. This isn't really viable for most users.

These patches allow the user to specify a port number that they would like the game to use for all peer-to-peer communications. Then, if the user forwards that UDP port in their router, it's equivalent to the DMZ/"NAT Type A" case and they should get better connectivity. Pretendo plans to ship similar patches to console players so we can maximise the number of port-forwarded users in the online population (the port number will be automatically chosen on hardware - I couldn't work out a good way to do this in Cemu though).

Minecraft is on a much newer NEX library version which is why it has a substantially different patch.

This is my first time contributing Cemu graphic packs, feel free to let me know if I misunderstood which folder to put these in or how to write the description or the like and I'll happily fix it.