### PR TITLE
[BotW] Use Extreme Quality for FXAA

### DIFF
--- a/src/BreathOfTheWild/Graphics/f14bb57cd5c9cb77_00000000000003c9_ps.txt
+++ b/src/BreathOfTheWild/Graphics/f14bb57cd5c9cb77_00000000000003c9_ps.txt
@@ -1,4 +1,4 @@
-#version 420
+#version 430
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
 #ifdef VULKAN
@@ -207,7 +207,7 @@ passPixelColor0 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 
 #define FXAA_PC 1
 #define FXAA_GLSL_130 1
-#define FXAA_QUALITY_PRESET 14
+#define FXAA_QUALITY_PRESET 39
 
 #define FXAA_GREEN_AS_LUMA 1
 #define FXAA_DISCARD 0


### PR DESCRIPTION
FXAA quality at Extreme. Performance remains the same and the result is less pixelated and sharper.