### PR TITLE
[Skylanders] Fix speed-up above 120 FPS (SSA, SG and STT)

### DIFF
--- a/src/SkylandersGiants/Mods/FPS/patch_dt.asm
+++ b/src/SkylandersGiants/Mods/FPS/patch_dt.asm
@@ -1,0 +1,4 @@
+[SG_dt]
+moduleMatches = 0x62CC63A5
+
+0x02110EF4 = nop

--- a/src/SkylandersGiants/Mods/FPS/rules.txt
+++ b/src/SkylandersGiants/Mods/FPS/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 000500001010D700,0005000010116000
 name = FPS
 path = "Skylanders: Giants/Mods/FPS"
-description = Changes the game's FPS limit.|Running the game with a high FPS limit can result in glitches.||Made by DigitNetics and Mew00.
+description = Changes the game's FPS limit. The speed of some things is tied to the frame rate.||Made by DigitNetics and Mew00. Fix for speed-up above 120 FPS by SuperSamus and Winner Nombre.
 version = 7
 
 [Default]

--- a/src/SkylandersImaginators/Mods/FPS/rules.txt
+++ b/src/SkylandersImaginators/Mods/FPS/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 00050000101F4D00,00050000101FB100
 name = FPS
 path = "Skylanders Imaginators/Mods/FPS"
-description = Changes the game's dynamic FPS target.||Needs to be disabled during certain sections, as it makes them impossible to complete:|- Sky Fortress: wrecking ball minigame (enemies are barely pushed)|- Golden Arcade: target shooting minigame (projectiles despawn before being able to reach some targets)|- Enchanted Elven Forest: water cannon near end of level (the splash is unable to put out the most distant fire)||Other minor issues:|- General: jump height is a little shorter, making some vertical jumps inconsistent|-Selfie mode: camera controls are too fast|- Cradle of Creation: hamster wheel rotates too fast||Made by Mew00. Fall respawn fix by SuperSamus and Winner Nombre.
+description = Changes the game's FPS limit.||Needs to be disabled during certain sections, as it makes them impossible to complete:|- Sky Fortress: wrecking ball minigame (enemies are barely pushed)|- Golden Arcade: target shooting minigame (projectiles despawn before being able to reach some targets)|- Enchanted Elven Forest: water cannon near end of level (the splash is unable to put out the most distant fire)||Other minor issues:|- General: jump height is a little shorter, making some vertical jumps inconsistent|-Selfie mode: camera controls are too fast|- Cradle of Creation: hamster wheel rotates too fast||Made by Mew00. Fall respawn fix by SuperSamus and Winner Nombre.
 version = 6
 
 [Default]

--- a/src/SkylandersSpyrosAdventure/Mods/FPS/patch_dt.asm
+++ b/src/SkylandersSpyrosAdventure/Mods/FPS/patch_dt.asm
@@ -1,0 +1,4 @@
+[SSA_dt]
+moduleMatches = 0xC22A1809
+
+0x021129A4 = nop

--- a/src/SkylandersSpyrosAdventure/Mods/FPS/rules.txt
+++ b/src/SkylandersSpyrosAdventure/Mods/FPS/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010142d00
 name = FPS V2
 path = "Skylanders: Spyro's Adventure/Mods/FPS"
-description = Changes the game's dynamic FPS target. Might increase the chance of issues with scanning figures.||Made by Mr.Blinker
+description = Changes the game's FPS limit. The speed of some things is tied to the frame rate.||Made by Mr.Blinker. Fix for speed-up above 120 FPS by SuperSamus and Winner Nombre.
 version = 6
 
 [Default]

--- a/src/SkylandersSwapForce/Mods/FPS/rules.txt
+++ b/src/SkylandersSwapForce/Mods/FPS/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 0005000010139200,0005000010140400
 name = FPS
 path = "Skylanders Swap Force/Mods/FPS"
-description = Changes the game's dynamic FPS target. Might have bugs, especially when going above 120 FPS.||Made by Mew00 for Imaginators, added by TheSkyDude134 for Swap Force. Infinite fall fix by SuperSamus and Winner Nombre.
+description = Changes the game's FPS limit. Might have bugs, especially when going above 120 FPS.||Made by Mew00 for Imaginators, added by TheSkyDude134 for Swap Force. Infinite fall fix by SuperSamus and Winner Nombre.
 version = 6
 
 [Default]

--- a/src/SkylandersTrapTeam/Mods/FPS/patch_dt.asm
+++ b/src/SkylandersTrapTeam/Mods/FPS/patch_dt.asm
@@ -1,0 +1,9 @@
+[STT_dt_V16]
+moduleMatches = 0x2A14BB42
+
+0x0210116C = b .+0xC
+
+[STT_dt_V1]
+moduleMatches = 0x321D97F0
+
+0x021016D8 = b .+0xC

--- a/src/SkylandersTrapTeam/Mods/FPS/rules.txt
+++ b/src/SkylandersTrapTeam/Mods/FPS/rules.txt
@@ -2,7 +2,7 @@
 titleIds = 000500001017C600,0005000010181F00
 name = FPS
 path = "Skylanders Trap Team/Mods/FPS"
-description = Changes the game's dynamic FPS target. Might have bugs, especially when going above 120 FPS.||Made by Mew00.
+description = Changes the game's FPS limit. The speed of some things is tied to the frame rate.||Made by Mew00. Fix for speed-up above 120 FPS by SuperSamus and Winner Nombre.
 version = 6
 
 [Default]


### PR DESCRIPTION
When going above 120 FPS on Skylanders: Spyro's Adventure, Giants, or Trap Team, the game would speed up.
This is because Toys for Bob went out of their way to explicitly code this behavior.

Why would they do this, especially on games that are console exclusive?[^1] Truly one of humankind biggest mysteries...

Anyway, this PR patches out this behavior, so that the game will always run at the correct speed (except for the things where the developers forgot to multiply by delta time: those aren't fixed.)

(Also took the opportunity to make small changes to the descriptions of the other games.)

Credits to @WinnerNombre for porting the patch to the Wii U games.

[^1]: Before you say "but SSA is also on PC": that version (along with the PS3 and Xbox 360 versions) runs on a completely different engine, so it doesn't count. Also, it's capped at 60 FPS anyway.