### PR TITLE
Imaginators Portal Fix

### DIFF
--- a/Imaginators Portal Fix
+++ b/Imaginators Portal Fix
@@ -1,0 +1,2 @@
+Added the file to fix the Skylanders Imaginators corrupt loop
+It is basicly the bypass NFC card but as a mod. wich can be anabled all the time


### PR DESCRIPTION
This graphics pack mod will allow you to bypass the corrupt figure loop if you want to use Sanseis, Villains or Creation Crystals .sky files created with Cemu
I did not make the files to fix the Imaginators emulated portal.
I found it from here https://drive.google.com/file/d/1_Q8gcjfHACx9L9o640CxAka-9Hmccdew/view
I believe the person who made the files doesn't mind it being added to Cemus graphics pack collection because
he made a video on YT where he shared links showcasing the files. so all credit to https://www.youtube.com/@moltenlavacore