### PR TITLE
[Splatoon] Add "Disable Autorotate" Mod

### DIFF
--- a/src/Splatoon/Mods/Disable Autorotate/patch_autorotate.asm
+++ b/src/Splatoon/Mods/Disable Autorotate/patch_autorotate.asm
@@ -1,0 +1,4 @@
+[begone_autorotate]
+moduleMatches = 0xF7A78809, 0x659c782e
+
+0x02664f20 = nop

--- a/src/Splatoon/Mods/Disable Autorotate/rules.txt
+++ b/src/Splatoon/Mods/Disable Autorotate/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010176900,0005000010176A00,0005000010162B00
+name = Disable Autorotate
+path = "Splatoon/Mods/Disable Autorotate"
+description = Prevents the camera from automatically rotating when the player moves left or right.
+version = 7


### PR DESCRIPTION
This removes the function call that rotates the camera when the player moves left or right. This makes it much easier to control your aim with both motion and mouse (via Xapfish) since you don't have to fight against the camera when you move.