### PR TITLE
[Skylanders] Remove Portal Check SWAP-Force

### DIFF
--- a/src/SkylandersSwapForce/Mods/Remove Portal Check/patch_RemovePortalCheck.asm
+++ b/src/SkylandersSwapForce/Mods/Remove Portal Check/patch_RemovePortalCheck.asm
@@ -1,0 +1,9 @@
+[SSF_RemovePortalCheck_V16]
+moduleMatches = 0xa0b35374 ; v16
+
+0x024B0A28 = li r3, 0x203
+
+[SSF_RemovePortalCheck_V0]
+moduleMatches = 0xb1f102ec ; v0
+
+0x024B09A0 = li r3, 0x203

--- a/src/SkylandersSwapForce/Mods/Remove Portal Check/rules.txt
+++ b/src/SkylandersSwapForce/Mods/Remove Portal Check/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010139200,0005000010140400
+name = Allow Portals From Other Skylanders Games
+path = "Skylanders SWAP-Force/Mods/Allow Portals From Other Skylanders Games"
+description = Allows any (non-Xbox!) Portal of Power to be used.||Made by Winner Nombre.
+version = 7


### PR DESCRIPTION
Removes the need to use the portal that came with SWAP-Force (or the games that came after it). This lets you use the Spyro's Adventure or the Giants portal for example.

This is basically the SWAP-Force version of this https://github.com/cemu-project/cemu_graphic_packs/pull/673