### PR TITLE
[Skylanders] Fix the path for Remove Portal Check SWAP-Force 

### DIFF
--- a/src/SkylandersSwapForce/Mods/Remove Portal Check/rules.txt
+++ b/src/SkylandersSwapForce/Mods/Remove Portal Check/rules.txt
@@ -1,6 +1,6 @@
 [Definition]
 titleIds = 0005000010139200,0005000010140400
 name = Allow Portals From Other Skylanders Games
-path = "Skylanders SWAP-Force/Mods/Allow Portals From Other Skylanders Games"
+path = "Skylanders Swap Force/Mods/Allow Portals From Other Skylanders Games"
 description = Allows any (non-Xbox!) Portal of Power to be used.||Made by Winner Nombre.
 version = 7


### PR DESCRIPTION
I used an old rules.txt I had as a base to make this https://github.com/cemu-project/cemu_graphic_packs/pull/698 and only noticed now that the path in my graphic pack is not consistent with the others, oops.
The path starts with "Skylanders SWAP-Force/..." but the other graphic packs use "Skylanders Swap Force/..."

Sorry about that