### PR TITLE
Workaround for Epic Mickey 2 Graphical Issue

### DIFF
--- a/Workarounds/DisneyEpicMickey2_GreenOverlayFix/patch_greenfix.asm
+++ b/Workarounds/DisneyEpicMickey2_GreenOverlayFix/patch_greenfix.asm
@@ -1,0 +1,14 @@
+[DEM2GreenFixVer0]
+moduleMatches = 0x7d954baf
+
+.origin = codecave
+
+_codeCaveFunction:
+lis r3, 0x13ad
+addi r3, r3, 0x7b7f
+li r4, 1
+stb r4, 0(r3)
+lwz r9,0x4(r23)
+blr
+
+0x021BEAF0 = bla _codeCaveFunction

--- a/Workarounds/DisneyEpicMickey2_GreenOverlayFix/rules.txt
+++ b/Workarounds/DisneyEpicMickey2_GreenOverlayFix/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 000500001010db00
+name = Green Overlay Fix
+path = "Disney Epic Mickey 2/Fixes/Green Overlay Fix"
+description = Removes the green overlay bug found specifically with emulation. Made by abso1utezer0.
+version = 7


### PR DESCRIPTION
Fixes the green tint over the screen that only appears in Cemu. Still no clue why this happens, but its fixed, so...