### PR TITLE
Skylanders: Use `r3` in the falling respawn fixes

### DIFF
--- a/src/SkylandersSuperChargers/Mods/FPS/patch_FixInfiniteFall.asm
+++ b/src/SkylandersSuperChargers/Mods/FPS/patch_FixInfiniteFall.asm
@@ -6,13 +6,13 @@ const_stuckFallingDistanceThreshold:
 .float 20*30/$targetFPS
 
 _getStuckFallingDistanceThreshold_f13:
-    lis r0, const_stuckFallingDistanceThreshold@ha
-    lfs f13, const_stuckFallingDistanceThreshold@l(r0)
+    lis r3, const_stuckFallingDistanceThreshold@ha
+    lfs f13, const_stuckFallingDistanceThreshold@l(r3)
 blr
 
 _getStuckFallingDistanceThreshold_f0:
-    lis r0, const_stuckFallingDistanceThreshold@ha
-    lfs f0, const_stuckFallingDistanceThreshold@l(r0)
+    lis r3, const_stuckFallingDistanceThreshold@ha
+    lfs f0, const_stuckFallingDistanceThreshold@l(r3)
 blr
 
 [SSC_FixInfiniteFall_V1]

--- a/src/SkylandersSwapForce/Mods/FPS/patch_FixInfiniteFall.asm
+++ b/src/SkylandersSwapForce/Mods/FPS/patch_FixInfiniteFall.asm
@@ -6,8 +6,8 @@ const_stuckFallingDistanceThreshold:
 .float 20*30/$targetFPS
 
 _getStuckFallingDistanceThreshold:
-    lis r0, const_stuckFallingDistanceThreshold@ha
-    lfs f0, const_stuckFallingDistanceThreshold@l(r0)
+    lis r3, const_stuckFallingDistanceThreshold@ha
+    lfs f0, const_stuckFallingDistanceThreshold@l(r3)
 blr
 
 [SSF_FixInfiniteFall_V16]


### PR DESCRIPTION
Fixes #639.
The patch used `r0` as a temporary register. In PowerPC, using `r0` as an argument in load instructions means `0` instead of the value of the register, meaning that we were loading address `00000000`.
Thus, the patch was doing undefined behavior, and was breaking the intended behavior of the function that was patched (respawning you when you are *actually* stuck). Whoops...
Now it uses `r3` instead.