### PR TITLE
[BotW] Add 90 FPS preset for Advanced Mode in FPS++

### DIFF
--- a/src/BreathOfTheWild/Mods/FPS++/rules.txt
+++ b/src/BreathOfTheWild/Mods/FPS++/rules.txt
@@ -174,6 +174,13 @@ $fpsLimitAdvanced = 120
 $keepVsync:int = 0
 
 [Preset]
+name = 90FPS (ideal for 90/180/360Hz displays)
+category = Framerate Limit
+condition = $advancedMode == 1
+$fpsLimitAdvanced = 90
+$keepVsync:int = 0
+
+[Preset]
 name = 75FPS (ideal for 75Hz displays)
 category = Framerate Limit
 condition = $advancedMode == 1


### PR DESCRIPTION
90 FPS option was missing for Advanced Mode in FPS++

Needed it for my 180Hz display ([AOC 24G4X](https://aoc.com/us/gaming/products/monitors/24g4x))